### PR TITLE
Clone options rather than storing reference

### DIFF
--- a/src/ExternalTemplateSource.js
+++ b/src/ExternalTemplateSource.js
@@ -4,7 +4,7 @@ var ExternalTemplateSource = function(templateId, options) {
     self.loaded = false;
     self.template = ko.observable(infuser.defaults.useLoadingTemplate ? infuser.defaults.loadingTemplate.content : undefined);
     self.template.data = {};
-    self.options = options || {};
+    self.options = ko.utils.extend({},options);
     self.options.templateId = templateId;
     if(self.options && self.options.afterRender) {
         origAfterRender = self.options.afterRender;


### PR DESCRIPTION
I experienced an issue using the template binding to dynamically select templates:

template: {foreach: computed()}

The last template computed was used for each row, rather than having each row with their own template.

This commit changes usage of options parameter in ExternalTemplateSource constructor to clone the options object rather than storing a reference to it.
