### PR TITLE
Repaired prevent erroneous afterRender triggers

### DIFF
--- a/src/ExternalTemplateSource.js
+++ b/src/ExternalTemplateSource.js
@@ -8,7 +8,7 @@ var ExternalTemplateSource = function(templateId, options) {
     self.options.templateId = templateId;
     if(self.options && self.options.afterRender) {
         origAfterRender = self.options.afterRender;
-        self.options.afterRender = function() {
+        options.afterRender = function() {
             if(self.loaded) {
                 origAfterRender.apply(self.options, arguments);
             }


### PR DESCRIPTION
Repaired the workaround that prevented afterRender from being triggered on the "Loading..." text being shown.
afterRender replacement was being done to options only internal to ExternalTemplateSource so the binding's options weren't being changed.
