### PR TITLE
added 'loaded' to the template binding

### DIFF
--- a/src/ExternalTemplateSource.js
+++ b/src/ExternalTemplateSource.js
@@ -45,6 +45,12 @@ ko.utils.extend(ExternalTemplateSource.prototype, {
             self.data("precompiled",null);
             self.template(tmpl);
             self.loaded = true;
+            if( ko.isWriteableObservable( self.options.loaded ) ) {
+				setTimeout(function(){
+					self.options.loaded(true);
+				}, 0);
+			}
+            
         });
     }
 });


### PR DESCRIPTION
If you pass a writeable observable named 'loaded' to the template bindgin, you can get notified when the template is actually loaded.
